### PR TITLE
fix: change default output-dir

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -12,7 +12,7 @@ import (
 
 func execCmd() *ffcli.Command {
 	execFlagSet := flag.NewFlagSet("exec", flag.ExitOnError)
-	outputDir := execFlagSet.String("outputDir", "pyroscope-ci", "where the generated profiles will be saved to. only available if --no-upload is set")
+	outputDir := execFlagSet.String("outputDir", "pyroscope-ci-output", "where the generated profiles will be saved to. only available if --no-upload is set")
 	serverAddress := execFlagSet.String("serverAddress", "https://pyroscope.cloud", "")
 	apiKey := execFlagSet.String("apiKey", "", "")
 	commitSHA := execFlagSet.String("commitSHA", "", "the commit sha")


### PR DESCRIPTION
Closes https://github.com/pyroscope-io/ci/issues/22
Considering this a bugfix since it simply shouldn't work out of the box (since it conflicts with the binary name), althought it's technically a breaking change.