### PR TITLE
feat: allow uploading and exporting at the same time

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -12,12 +12,14 @@ import (
 
 func execCmd() *ffcli.Command {
 	execFlagSet := flag.NewFlagSet("exec", flag.ExitOnError)
-	outputDir := execFlagSet.String("outputDir", "pyroscope-ci-output", "where the generated profiles will be saved to. only available if --no-upload is set")
+
+	export := execFlagSet.Bool("export", false, "exports data to a local directory, used in conjunction with --outputDir")
+	outputDir := execFlagSet.String("outputDir", "pyroscope-ci-output", "where the generated profiles will be saved to. only available if --export is set")
 	serverAddress := execFlagSet.String("serverAddress", "https://pyroscope.cloud", "")
 	apiKey := execFlagSet.String("apiKey", "", "")
 	commitSHA := execFlagSet.String("commitSHA", "", "the commit sha")
 	branch := execFlagSet.String("branch", "", "")
-	noUpload := execFlagSet.Bool("noUpload", false, "whether to upload automatically or to store into a local directory")
+	noUpload := execFlagSet.Bool("noUpload", false, "disables uploading")
 	logLevel := execFlagSet.String("logLevel", "info", "")
 
 	return &ffcli.Command{
@@ -38,6 +40,7 @@ func execCmd() *ffcli.Command {
 				NoUpload:      *noUpload,
 				Branch:        *branch,
 				LogLevel:      *logLevel,
+				Export:        *export,
 			})
 
 			// If exec failed, print it first

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -15,7 +15,7 @@ func TestCapturingCmdError(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	// Running an unknown command, we should get back an error
-	cfg := exec.ExecCfg{NoUpload: true, OutputDir: dir}
+	cfg := exec.ExecCfg{NoUpload: true, Export: true, OutputDir: dir}
 	cmdError, err := exec.Exec([]string{"unknown command"}, cfg)
 	if err != nil {
 		t.Error("did not expect error to happen")

--- a/internal/exec/uploader.go
+++ b/internal/exec/uploader.go
@@ -75,6 +75,7 @@ func (u *Uploader) uploadSingle(_ context.Context, item flamebearer.FlamebearerP
 	}
 
 	file := bytes.NewReader(marshalled)
+
 	// TODO: get the whole url from the config?
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/api/ci-events", serverAddress), file)
 	if err != nil {
@@ -104,7 +105,7 @@ func (u *Uploader) uploadSingle(_ context.Context, item flamebearer.FlamebearerP
 	var respBody []byte
 	_, err = res.Body.Read(respBody)
 	if err != nil {
-		return fmt.Errorf("read response body: %v", err)
+		return fmt.Errorf("error reading response body: '%v'. the request had statusCode %d", err, res.StatusCode)
 	}
 
 	if res.StatusCode != http.StatusOK {


### PR DESCRIPTION
Now one can both export data to a local dir and upload to a remote server. This allows taking the output and uploading to flamegraph.com using https://github.com/pyroscope-io/flamegraph.com-github-action

This change is a slightly breaking one, but I believe no one should be relying on the previous behaviour (where `--noUpload` also makes it write to a local dir).