### PR TITLE
docs: add ruby (rspec) example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ pyroscope_test.go
 node_modules
 **/pyroscope-ci-output/*.json
 **/pyroscope-ci
+
+examples/ruby/**/bin
+examples/ruby/**/.rspec_status
+examples/ruby/**/.bundle

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -67,3 +67,16 @@ func TestGo(t *testing.T) {
 		Dir: "./examples/go",
 	})
 }
+
+func TestRubyRspec(t *testing.T) {
+	containerName, cleanupProxy := StartProxy(t)
+	t.Cleanup(cleanupProxy)
+
+	testscript.Run(t, testscript.Params{
+		Setup: Setup(
+			SetProxyAddressEnvVar(containerName),
+			BuildImage("./examples/ruby/rspec", "ruby-rspec"),
+		),
+		Dir: "./examples/ruby/rspec",
+	})
+}

--- a/examples/ruby/rspec/Dockerfile
+++ b/examples/ruby/rspec/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:3.2.1
+
+WORKDIR /usr/src/app
+
+COPY Gemfile ./
+COPY Gemfile.lock ./
+COPY fib.rb ./
+COPY spec spec/
+
+RUN bundle install --binstubs
+
+CMD ["ruby", "main.rb"]
+

--- a/examples/ruby/rspec/Gemfile
+++ b/examples/ruby/rspec/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+gem 'rspec', '~> 3.0'
+
+gem "pyroscope", "~> 0.5.2"

--- a/examples/ruby/rspec/Gemfile.lock
+++ b/examples/ruby/rspec/Gemfile.lock
@@ -1,0 +1,30 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.5.0)
+    ffi (1.15.5)
+    pyroscope (0.5.2-arm64-darwin)
+      ffi
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.1)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
+
+PLATFORMS
+  arm64-darwin-21
+
+DEPENDENCIES
+  pyroscope (~> 0.5.2)
+  rspec (~> 3.0)
+
+BUNDLED WITH
+   2.4.6

--- a/examples/ruby/rspec/fib.rb
+++ b/examples/ruby/rspec/fib.rb
@@ -1,0 +1,8 @@
+def fib(n)
+  if n < 2 then
+    n
+  else
+    fib(n-1) + fib(n-2)
+  end
+end
+

--- a/examples/ruby/rspec/spec/fib_spec.rb
+++ b/examples/ruby/rspec/spec/fib_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+require_relative '../fib'
+
+RSpec.describe do
+  it "calculates fib" do
+    expect(fib(42)).to eq(267914296)
+  end
+end

--- a/examples/ruby/rspec/spec/spec_helper.rb
+++ b/examples/ruby/rspec/spec/spec_helper.rb
@@ -18,6 +18,7 @@ end
 RSpec.configure do |config|
   config.before(:suite) do
     Pyroscope.configure do |config|
+      config.server_address = ENV["PYROSCOPE_ADHOC_SERVER_ADDRESS"]
       config.application_name = "ruby.tests"
     end
   end

--- a/examples/ruby/rspec/spec/spec_helper.rb
+++ b/examples/ruby/rspec/spec/spec_helper.rb
@@ -1,0 +1,25 @@
+require "bundler/setup"
+require "rspec"
+require "pyroscope"
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end
+
+# Enable pyroscope
+RSpec.configure do |config|
+  config.before(:suite) do
+    Pyroscope.configure do |config|
+      config.application_name = "ruby.tests"
+    end
+  end
+end
+

--- a/examples/ruby/rspec/testscripts.txtar
+++ b/examples/ruby/rspec/testscripts.txtar
@@ -1,3 +1,3 @@
 pyroscope-ci exec --noUpload --export -- docker run --link $PYROSCOPE_PROXY_ADDRESS --env PYROSCOPE_ADHOC_SERVER_ADDRESS $IMAGE_NAME ./bin/rspec
-#exists pyroscope-ci-output/ruby.tests.cpu.json
+exists pyroscope-ci-output/ruby.tests.cpu.json
 

--- a/examples/ruby/rspec/testscripts.txtar
+++ b/examples/ruby/rspec/testscripts.txtar
@@ -1,0 +1,3 @@
+pyroscope-ci exec --noUpload --export -- docker run --link $PYROSCOPE_PROXY_ADDRESS --env PYROSCOPE_ADHOC_SERVER_ADDRESS $IMAGE_NAME ./bin/rspec
+#exists pyroscope-ci-output/ruby.tests.cpu.json
+


### PR DESCRIPTION
Adds a ruby example using rspec.

It manually sets `server_address` based on `PYROSCOPE_ADHOC_SERVER_ADDRESS` since the agent doesn't support it (https://github.com/pyroscope-io/pyroscope-rs/issues/88)

Also it relies on requiring `spec_helper`, which seems to be a common approach (
https://github.com/search?q=require+%27spec_helper%27&type=code)

Flamegraph for reference: https://flamegraph.com/share/66cdb214-b38c-11ed-b290-023a7a0d8f77
<img src="https://flamegraph.com/api/preview/66cdb214-b38c-11ed-b290-023a7a0d8f77?size=full" />